### PR TITLE
Fix regex to properly validate non-negative integer strings

### DIFF
--- a/src/Base32.php
+++ b/src/Base32.php
@@ -241,7 +241,7 @@ class Base32 {
      */
     private static function _intStrToByteStr($intStr) {
         // Check if given value is a positive integer (string).
-        if (!preg_match('/[0-9]+/', (string) $intStr)) {
+        if (!preg_match('/^[0-9]+$/', (string) $intStr)) {
             $msg = 'Argument 1 must be a non-negative integer or a string representing a non-negative integer.';
             throw new InvalidArgumentException($msg, self::E_NO_NON_NEGATIVE_INT);
         }
@@ -611,7 +611,7 @@ class Base32 {
      */
     private static function _crockfordEncodeIntStr($intStr, $alphabet) {
         // Check if given value is a non-negative integer(-string).
-        if (!preg_match('/[0-9]+/', (string) $intStr)) {
+        if (!preg_match('/^[0-9]+$/', (string) $intStr)) {
             $msg = 'Argument 1 must be a non-negative integer or a string representing a non-negative integer.';
             throw new InvalidArgumentException($msg, self::E_NO_NON_NEGATIVE_INT);
         }


### PR DESCRIPTION
This pull request fixes the validation logic in the function that checks whether a given value is a positive integer (or a string representing a positive integer). The previous regex pattern '/[0-9]+/' only checked for the presence of one or more numeric characters but allowed invalid inputs like "abc123" or "123abc".

The updated regex '/^[0-9]+$/' ensures that the entire string consists solely of digits, representing a valid non-negative integer. This guarantees the proper validation of inputs.